### PR TITLE
Deprecate Permonitor mode intended only for Windows 8.1

### DIFF
--- a/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
+++ b/src/System.Windows.Forms.Primitives/src/System/Windows/Forms/HighDpiMode.cs
@@ -37,8 +37,9 @@ namespace System.Windows.Forms
         SystemAware,
 
         /// <summary>
-        ///  The window checks for DPI when it's created and adjusts scale factor when the DPI changes.
+        /// The window checks for DPI when it's created and adjusts scale factor when the DPI changes.
         /// </summary>
+        [Obsolete("Permonitor mode is applicable only on Windows 8.1. Winforms does not support this mode", true)]
         PerMonitor,
 
         /// <summary>


### PR DESCRIPTION
Winforms never fuly supported this mode. Windows 10 and above versions use 'PermonitorV2' mode.

<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #


## Proposed changes

- 
- 
- 

<!-- We are in TELL-MODE the following section must be completed -->

## Customer Impact

- 
- 

## Regression? 

- Yes / No

## Risk

-

<!-- end TELL-MODE -->


## Screenshots <!-- Remove this section if PR does not change UI -->

### Before

<!-- TODO -->

### After

<!-- TODO -->


## Test methodology <!-- How did you ensure quality? -->

- 
- 
- 

## Accessibility testing  <!-- Remove this section if PR does not change UI -->

<!--
     Microsoft prioritizes making our products accessible. 
     WinForms has a key role in allowing developers to create accessible apps. 
     
     When submitting a change which impacts UI in any way, including adding new UI or
     modifying existing controls the developer needs to run the Accessibility Insights
     tool (https://accessibilityinsights.io/) and verify that there are no changes or
     regressions. 
     
     The developer should run the Fast Pass over the impacted control(s) and provide
     a snapshot of the passing results along with before/after snapshots of the UI.
     More info: (https://accessibilityinsights.io/docs/en/web/getstarted/fastpass)
  -->


 

## Test environment(s) <!-- Remove any that don't apply -->

- <!-- use `dotnet --info` -->


<!-- Mention language, UI scaling, or anything else that might be relevant -->
